### PR TITLE
feat: phase 2 — AI document structurer with Gemini + Groq fallback

### DIFF
--- a/docstream/core/structurer.py
+++ b/docstream/core/structurer.py
@@ -1,14 +1,19 @@
 """
 AI-powered content structuring for document organization.
 
-The Structurer class uses AI models to organize raw content into
-structured DocumentAST with proper hierarchy and relationships.
+The DocumentStructurer class takes List[Block] from the extractor and uses
+Gemini 1.5 Flash (primary) or Groq llama-3.1-70b (fallback) to produce a
+structured DocumentAST. Keys are loaded from a .env file via python-dotenv.
 """
 
+import json
 import logging
+import re
+import time
 import warnings
-from abc import ABC, abstractmethod
 from typing import Any
+
+from dotenv import load_dotenv
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", FutureWarning)
@@ -18,342 +23,340 @@ from groq import Groq
 from docstream.exceptions import StructuringError
 from docstream.models.document import (
     Block,
-    BlockType,
     DocumentAST,
     DocumentMetadata,
-    HeadingBlock,
-    RawContent,
+    Image,
     Section,
-    TextBlock,
+    Table,
 )
+
+load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Prompt constants
+# ---------------------------------------------------------------------------
 
-class BaseStructurer(ABC):
-    """Abstract base class for content structurers."""
+_EXAMPLE_OUTPUT = """{
+  "title": "Example Document",
+  "authors": ["Jane Doe"],
+  "abstract": "A brief summary of the document.",
+  "sections": [
+    {
+      "heading": "Introduction",
+      "level": 1,
+      "content": ["First paragraph text.", "Second paragraph text."],
+      "tables": [],
+      "images": [],
+      "subsections": [
+        {
+          "heading": "Background",
+          "level": 2,
+          "content": ["Background paragraph."],
+          "tables": [],
+          "images": [],
+          "subsections": []
+        }
+      ]
+    }
+  ],
+  "metadata": {}
+}"""
 
-    @abstractmethod
-    def structure(self, raw_content: RawContent) -> DocumentAST:
-        """Structure raw content into DocumentAST.
+_SYSTEM_PROMPT = (
+    "You are a document structure expert. Analyze the document content blocks below "
+    "and produce a structured JSON representation.\n\n"
+    "Rules:\n"
+    "1. Return ONLY valid JSON — no markdown fences, no commentary, no preamble.\n"
+    "2. Use font_size hints to detect headings: larger font_size = higher heading level.\n"
+    '3. Group consecutive paragraphs as the "content" list of their parent section.\n'
+    "4. Nest subsections logically (level 1 > level 2 > level 3).\n"
+    "5. Preserve table and image references exactly as provided.\n\n"
+    "Expected output format:\n" + _EXAMPLE_OUTPUT
+)
+
+_STRICT_SUFFIX = (
+    "\n\nCRITICAL: Your entire response must be a single valid JSON object. "
+    "No markdown, no prose, no code fences."
+)
+
+# ~8 000 tokens ≈ 32 000 chars; reserve space for system prompt + framing
+_MAX_CONTENT_CHARS = 30_000
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+
+class DocumentStructurer:
+    """Structure a list of Blocks into a DocumentAST using Gemini / Groq."""
+
+    GEMINI_MODEL = "gemini-1.5-flash"
+    GROQ_MODEL = "llama-3.1-70b-versatile"
+    MAX_RETRIES = 2
+    _BACKOFF = [1, 2]
+
+    def __init__(self, gemini_key: str, groq_key: str | None = None) -> None:
+        """Initialise with explicit API keys (never hardcoded).
+
+        Keys are typically injected from os.environ after calling load_dotenv().
 
         Args:
-            raw_content: Raw content from extractor
+            gemini_key: Google Gemini API key.
+            groq_key: Groq API key (optional; used as fallback).
+        """
+        self._gemini_key = gemini_key
+        self._groq_key = groq_key
+        self._gemini_client: Any | None = None
+        self._groq_client: Any | None = None
+        self._init_clients()
+
+    def _init_clients(self) -> None:
+        if self._gemini_key:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                genai.configure(api_key=self._gemini_key)
+                self._gemini_client = genai.GenerativeModel(self.GEMINI_MODEL)
+        if self._groq_key:
+            self._groq_client = Groq(api_key=self._groq_key)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def structure(self, blocks: list[Block]) -> DocumentAST:
+        """Convert a list of Blocks into a DocumentAST.
+
+        Tries Gemini first (up to MAX_RETRIES), then Groq (up to MAX_RETRIES).
+        On the second attempt for any provider a stricter prompt is used.
+
+        Args:
+            blocks: Content blocks produced by the extractor.
 
         Returns:
-            DocumentAST with structured content
+            Validated DocumentAST.
 
         Raises:
-            StructuringError: If structuring fails
+            StructuringError: When both providers are exhausted or unavailable.
         """
-        pass
-
-
-class GeminiStructurer(BaseStructurer):
-    """Structurer using Google Gemini AI model."""
-
-    def __init__(self, api_key: str, model: str = "gemini-1.5-pro"):
-        """Initialize Gemini structurer.
-
-        Args:
-            api_key: Google Gemini API key
-            model: Gemini model to use
-        """
-        self.model_name = model
-        genai.configure(api_key=api_key)
-        self.model = genai.GenerativeModel(model)
-
-    def structure(self, raw_content: RawContent) -> DocumentAST:
-        """Structure content using Gemini AI."""
-        try:
-            logger.info(f"Structuring content with Gemini: {self.model_name}")
-
-            # Prepare prompt for Gemini
-            prompt = self._create_structuring_prompt(raw_content)
-
-            # Generate structured content
-            response = self.model.generate_content(prompt)
-
-            # Parse response into DocumentAST
-            return self._parse_response(response.text, raw_content.metadata)
-
-        except Exception as e:
-            logger.error(f"Gemini structuring failed: {e}")
-            raise StructuringError(f"Failed to structure content with Gemini: {e}")
-
-    def _create_structuring_prompt(self, raw_content: RawContent) -> str:
-        """Create prompt for AI structuring."""
-        prompt = f"""
-Analyze the following document content and structure it into a hierarchical format.
-
-Content:
-{raw_content.text[:10000]}  # Limit content length
-
-Please structure this content by:
-1. Identifying main sections and subsections
-2. Classifying content blocks (text, headings, lists, etc.)
-3. Organizing into a clear hierarchy
-
-Return the result in this JSON format:
-{{
-    "sections": [
-        {{
-            "title": "Section Title",
-            "level": 1,
-            "blocks": [
-                {{
-                    "type": "text|heading|list",
-                    "content": "Block content",
-                    "level": 1  // for headings
-                }}
-            ]
-        }}
-    ]
-}}
-"""
-        return prompt
-
-    def _parse_response(self, response_text: str, metadata: DocumentMetadata) -> DocumentAST:
-        """Parse AI response into DocumentAST."""
-        import json
-
-        try:
-            # Extract JSON from response
-            json_start = response_text.find("{")
-            json_end = response_text.rfind("}") + 1
-
-            if json_start == -1 or json_end == 0:
-                raise StructuringError("No valid JSON found in AI response")
-
-            json_text = response_text[json_start:json_end]
-            data = json.loads(json_text)
-
-            # Build DocumentAST
-            sections = []
-            for section_data in data.get("sections", []):
-                section = self._create_section(section_data)
-                sections.append(section)
-
-            return DocumentAST(
-                metadata=metadata, sections=sections, blocks=[], tables=[], images=[]
+        if not self._gemini_client and not self._groq_client:
+            raise StructuringError(
+                "No AI provider available. "
+                "Set GEMINI_API_KEY or GROQ_API_KEY (or pass keys directly)."
             )
 
-        except json.JSONDecodeError as e:
-            raise StructuringError(f"Failed to parse AI response as JSON: {e}")
+        prompt = self._build_prompt(blocks)
+        last_error: Exception | None = None
 
-    def _create_section(self, section_data: dict[str, Any]) -> Section:
-        """Create Section from data."""
-        blocks = []
+        if self._gemini_client:
+            result = self._run_with_retry("gemini", prompt)
+            if isinstance(result, DocumentAST):
+                return result
+            last_error = result
 
-        for block_data in section_data.get("blocks", []):
-            block = self._create_block(block_data)
-            blocks.append(block)
+        if self._groq_client:
+            result = self._run_with_retry("groq", prompt)
+            if isinstance(result, DocumentAST):
+                return result
+            last_error = result
 
-        return Section(
-            title=section_data.get("title", ""), level=section_data.get("level", 1), blocks=blocks
+        raise StructuringError(f"All providers failed. Last error: {last_error}")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_with_retry(self, provider: str, prompt: str) -> "DocumentAST | Exception":
+        """Run one provider with exponential-backoff retries.
+
+        Returns DocumentAST on success, or the last Exception on failure.
+        """
+        call_fn = self._call_gemini if provider == "gemini" else self._call_groq
+        last_exc: Exception = StructuringError("Unknown error")
+
+        for attempt in range(self.MAX_RETRIES):
+            current_prompt = prompt if attempt == 0 else prompt + _STRICT_SUFFIX
+            try:
+                logger.info(
+                    "%s attempt %d/%d",
+                    provider.capitalize(),
+                    attempt + 1,
+                    self.MAX_RETRIES,
+                )
+                raw = call_fn(current_prompt)
+                return self._parse_response(raw)
+            except StructuringError as exc:
+                last_exc = exc
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self._BACKOFF[attempt]
+                    logger.warning(
+                        "%s attempt %d failed, retrying in %ds: %s",
+                        provider.capitalize(),
+                        attempt + 1,
+                        wait,
+                        exc,
+                    )
+                    time.sleep(wait)
+            except Exception as exc:
+                last_exc = StructuringError(f"{provider.capitalize()} call error: {exc}")
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self._BACKOFF[attempt]
+                    logger.warning(
+                        "%s attempt %d failed, retrying in %ds: %s",
+                        provider.capitalize(),
+                        attempt + 1,
+                        wait,
+                        exc,
+                    )
+                    time.sleep(wait)
+
+        logger.warning("%s exhausted retries. Last error: %s", provider.capitalize(), last_exc)
+        return last_exc
+
+    def _call_gemini(self, prompt: str) -> str:
+        """Call Gemini API and return the raw text response."""
+        if not self._gemini_client:
+            raise StructuringError("Gemini client is not initialised.")
+        try:
+            response = self._gemini_client.generate_content(prompt)
+            return response.text
+        except Exception as exc:
+            raise StructuringError(f"Gemini API error: {exc}") from exc
+
+    def _call_groq(self, prompt: str) -> str:
+        """Call Groq API and return the raw text response."""
+        if not self._groq_client:
+            raise StructuringError("Groq client is not initialised.")
+        try:
+            response = self._groq_client.chat.completions.create(
+                model=self.GROQ_MODEL,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.1,
+                max_tokens=4096,
+            )
+            return response.choices[0].message.content
+        except Exception as exc:
+            raise StructuringError(f"Groq API error: {exc}") from exc
+
+    def _build_prompt(self, blocks: list[Block]) -> str:
+        """Build the structuring prompt, truncating blocks to stay under ~8 000 tokens."""
+        lines: list[str] = []
+        total = 0
+
+        for block in blocks:
+            font_hint = ""
+            if block.metadata.get("font_size"):
+                font_hint = f" [font_size={block.metadata['font_size']}]"
+            line = f"[{block.type}]{font_hint} {block.content}"
+
+            if total + len(line) > _MAX_CONTENT_CHARS:
+                lines.append("[...document truncated to fit token limit...]")
+                break
+
+            lines.append(line)
+            total += len(line)
+
+        blocks_text = "\n".join(lines)
+        return (
+            f"{_SYSTEM_PROMPT}\n\n"
+            "--- DOCUMENT BLOCKS ---\n"
+            f"{blocks_text}\n"
+            "--- END OF BLOCKS ---\n\n"
+            "Now return the structured JSON for this document:"
         )
 
-    def _create_block(self, block_data: dict[str, Any]) -> Block:
-        """Create Block from data."""
-        block_type = BlockType(block_data.get("type", "text"))
-        content = block_data.get("content", "")
+    def _parse_response(self, response: str) -> DocumentAST:
+        """Parse raw AI response into a DocumentAST.
 
-        if block_type == BlockType.HEADING:
-            return HeadingBlock(type=block_type, content=content, level=block_data.get("level", 1))
-        else:
-            return TextBlock(type=block_type, content=content)
-
-
-class GroqStructurer(BaseStructurer):
-    """Structurer using Groq AI model."""
-
-    def __init__(self, api_key: str, model: str = "llama3-70b-8192"):
-        """Initialize Groq structurer.
-
-        Args:
-            api_key: Groq API key
-            model: Groq model to use
+        Strips markdown fences if present. On validation failure raises
+        StructuringError so the retry loop can re-attempt with a stricter prompt.
         """
-        self.model_name = model
-        self.client = Groq(api_key=api_key)
+        cleaned = response.strip()
 
-    def structure(self, raw_content: RawContent) -> DocumentAST:
-        """Structure content using Groq AI."""
-        try:
-            logger.info(f"Structuring content with Groq: {self.model_name}")
+        # Strip ```json ... ``` or ``` ... ``` fences
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+        cleaned = re.sub(r"```\s*$", "", cleaned, flags=re.MULTILINE)
+        cleaned = cleaned.strip()
 
-            # Prepare prompt for Groq
-            prompt = self._create_structuring_prompt(raw_content)
-
-            # Generate structured content
-            response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.1,
-                max_tokens=4000,
-            )
-
-            # Parse response into DocumentAST
-            return self._parse_response(response.choices[0].message.content, raw_content.metadata)
-
-        except Exception as e:
-            logger.error(f"Groq structuring failed: {e}")
-            raise StructuringError(f"Failed to structure content with Groq: {e}")
-
-    def _create_structuring_prompt(self, raw_content: RawContent) -> str:
-        """Create prompt for AI structuring."""
-        # Similar to Gemini prompt but optimized for Groq
-        prompt = f"""
-Analyze and structure this document content:
-
-{raw_content.text[:8000]}
-
-Return a structured JSON with sections and blocks:
-{{
-    "sections": [
-        {{
-            "title": "Section Title",
-            "level": 1,
-            "blocks": [
-                {{
-                    "type": "text",
-                    "content": "Content here"
-                }}
-            ]
-        }}
-    ]
-}}
-"""
-        return prompt
-
-    def _parse_response(self, response_text: str, metadata: DocumentMetadata) -> DocumentAST:
-        """Parse AI response into DocumentAST."""
-        # Similar parsing logic as Gemini
-        import json
+        # Extract first complete JSON object
+        start = cleaned.find("{")
+        end = cleaned.rfind("}") + 1
+        if start == -1 or end == 0:
+            raise StructuringError("No JSON object found in response.")
+        cleaned = cleaned[start:end]
 
         try:
-            json_start = response_text.find("{")
-            json_end = response_text.rfind("}") + 1
+            data = json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            raise StructuringError(f"Invalid JSON in response: {exc}") from exc
 
-            if json_start == -1 or json_end == 0:
-                raise StructuringError("No valid JSON found in AI response")
-
-            json_text = response_text[json_start:json_end]
-            data = json.loads(json_text)
-
-            sections = []
-            for section_data in data.get("sections", []):
-                section = Section(
-                    title=section_data.get("title", ""),
-                    level=section_data.get("level", 1),
-                    blocks=[],
-                )
-
-                for block_data in section_data.get("blocks", []):
-                    block_type = BlockType(block_data.get("type", "text"))
-                    if block_type == BlockType.HEADING:
-                        block = HeadingBlock(
-                            type=block_type,
-                            content=block_data.get("content", ""),
-                            level=block_data.get("level", 1),
-                        )
-                    else:
-                        block = TextBlock(type=block_type, content=block_data.get("content", ""))
-                    section.blocks.append(block)
-
-                sections.append(section)
-
-            return DocumentAST(
-                metadata=metadata, sections=sections, blocks=[], tables=[], images=[]
+        if not self._validate_ast(data):
+            raise StructuringError(
+                "Response JSON failed DocumentAST validation "
+                "(missing required fields: title, sections[].heading, sections[].level)."
             )
 
-        except json.JSONDecodeError as e:
-            raise StructuringError(f"Failed to parse AI response as JSON: {e}")
+        return self._dict_to_ast(data)
+
+    def _validate_ast(self, ast: dict[str, Any]) -> bool:
+        """Return True only when the dict satisfies the minimum DocumentAST contract."""
+        if not isinstance(ast, dict):
+            return False
+        if "sections" not in ast or not isinstance(ast["sections"], list):
+            return False
+        for sec in ast["sections"]:
+            if not isinstance(sec, dict):
+                return False
+            if "heading" not in sec or "level" not in sec:
+                return False
+            if not isinstance(sec.get("content", []), list):
+                return False
+        return True
+
+    def _dict_to_ast(self, data: dict[str, Any]) -> DocumentAST:
+        """Convert a validated response dict into a DocumentAST instance."""
+        sections = [self._dict_to_section(s) for s in data.get("sections", [])]
+        metadata = DocumentMetadata(
+            title=data.get("title") or None,
+            abstract=data.get("abstract") or None,
+            custom_fields=data.get("metadata") or {},
+        )
+        return DocumentAST(
+            title=data.get("title", ""),
+            authors=data.get("authors", []),
+            abstract=data.get("abstract") or None,
+            metadata=metadata,
+            sections=sections,
+        )
+
+    def _dict_to_section(self, data: dict[str, Any]) -> Section:
+        """Recursively convert a section dict into a Section model instance."""
+        tables: list[Table] = []
+        for t in data.get("tables", []):
+            if isinstance(t, dict) and "headers" in t:
+                tables.append(Table(**t))
+
+        images: list[Image] = []
+        for img in data.get("images", []):
+            if isinstance(img, dict) and "src" in img:
+                images.append(Image(**img))
+
+        subsections = [self._dict_to_section(s) for s in data.get("subsections", [])]
+
+        return Section(
+            heading=data.get("heading", ""),
+            level=int(data.get("level", 1)),
+            content=data.get("content", []),
+            tables=tables,
+            images=images,
+            subsections=subsections,
+        )
 
 
-class Structurer:
-    """Main structurer class that manages AI-powered content organization."""
-
-    def __init__(
-        self,
-        gemini_api_key: str | None = None,
-        groq_api_key: str | None = None,
-        preferred_model: str = "gemini",
-        gemini_model: str = "gemini-1.5-pro",
-        groq_model: str = "llama3-70b-8192",
-    ):
-        """Initialize structurer with AI models.
-
-        Args:
-            gemini_api_key: Google Gemini API key
-            groq_api_key: Groq API key
-            preferred_model: Preferred AI model ("gemini" or "groq")
-            gemini_model: Specific Gemini model to use
-            groq_model: Specific Groq model to use
-        """
-        self.structurers = {}
-
-        if gemini_api_key:
-            self.structurers["gemini"] = GeminiStructurer(
-                api_key=gemini_api_key, model=gemini_model
-            )
-
-        if groq_api_key:
-            self.structurers["groq"] = GroqStructurer(api_key=groq_api_key, model=groq_model)
-
-        self.preferred_model = preferred_model
-
-    def structure(self, raw_content: RawContent) -> DocumentAST:
-        """Structure raw content into DocumentAST.
-
-        Args:
-            raw_content: Raw content from extractor
-
-        Returns:
-            DocumentAST with structured content
-
-        Raises:
-            StructuringError: If structuring fails
-        """
-        logger.info("Structuring document content")
-
-        if not self.structurers:
-            raise StructuringError("No AI structurers available. Check API keys.")
-
-        # Try preferred model first
-        if self.preferred_model in self.structurers:
-            try:
-                return self.structurers[self.preferred_model].structure(raw_content)
-            except Exception as e:
-                logger.warning(f"Preferred model {self.preferred_model} failed: {e}")
-
-        # Try other available models
-        for model_name, structurer in self.structurers.items():
-            if model_name != self.preferred_model:
-                try:
-                    logger.info(f"Falling back to {model_name}")
-                    return structurer.structure(raw_content)
-                except Exception as e:
-                    logger.warning(f"Model {model_name} failed: {e}")
-
-        raise StructuringError("All AI models failed to structure content")
-
-    def get_available_models(self) -> list[str]:
-        """Get list of available AI models."""
-        return list(self.structurers.keys())
-
-    def set_preferred_model(self, model: str) -> None:
-        """Set preferred AI model.
-
-        Args:
-            model: Model name ("gemini" or "groq")
-
-        Raises:
-            ValueError: If model is not available
-        """
-        if model not in self.structurers:
-            raise ValueError(
-                f"Model {model} not available. Available: {list(self.structurers.keys())}"
-            )
-
-        self.preferred_model = model
+# Backward-compatible alias
+Structurer = DocumentStructurer

--- a/tests/test_structurer.py
+++ b/tests/test_structurer.py
@@ -1,8 +1,5 @@
 """
-Tests for the Structurer module.
-
-This module contains unit tests for AI-powered content structuring.
-External AI API calls are mocked to keep tests fast and offline.
+Tests for DocumentStructurer — all API calls are mocked, no real network traffic.
 """
 
 import json
@@ -10,159 +7,237 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from docstream.core.structurer import GeminiStructurer, GroqStructurer, Structurer
+from docstream.core.structurer import _MAX_CONTENT_CHARS, DocumentStructurer
 from docstream.exceptions import StructuringError
-from docstream.models.document import (
-    DocumentAST,
-)
+from docstream.models.document import Block, BlockType, DocumentAST, TextBlock
 
-MOCK_AI_RESPONSE = json.dumps(
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_RESPONSE = json.dumps(
     {
+        "title": "Test Document",
+        "authors": ["Alice"],
+        "abstract": "An abstract.",
         "sections": [
             {
-                "title": "Introduction",
+                "heading": "Introduction",
                 "level": 1,
-                "blocks": [{"type": "text", "content": "This is the introduction."}],
+                "content": ["First paragraph.", "Second paragraph."],
+                "tables": [],
+                "images": [],
+                "subsections": [],
             }
-        ]
+        ],
+        "metadata": {},
     }
 )
 
+_FENCED_RESPONSE = f"```json\n{_VALID_RESPONSE}\n```"
 
-class TestGeminiStructurer:
-    """Unit tests for GeminiStructurer."""
 
-    @patch("docstream.core.structurer.genai")
-    def test_structure_returns_document_ast(self, mock_genai, sample_raw_content):
-        """GeminiStructurer.structure should return a DocumentAST."""
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = MOCK_AI_RESPONSE
-        mock_genai.GenerativeModel.return_value = mock_model
+def _make_blocks(n: int = 2) -> list[Block]:
+    return [TextBlock(type=BlockType.TEXT, content=f"Paragraph {i}.") for i in range(n)]
 
-        structurer = GeminiStructurer(api_key="fake_key")
-        result = structurer.structure(sample_raw_content)
+
+def _structurer(gemini_key: str = "fake-gemini", groq_key: str = "fake-groq") -> DocumentStructurer:
+    """Return a DocumentStructurer whose clients are replaced with MagicMocks."""
+    with patch("docstream.core.structurer.genai"):
+        with patch("docstream.core.structurer.Groq"):
+            ds = DocumentStructurer(gemini_key=gemini_key, groq_key=groq_key)
+    ds._gemini_client = MagicMock()
+    ds._groq_client = MagicMock()
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStructureReturnsValidAst:
+    def test_structure_returns_valid_ast(self):
+        """Gemini returns valid JSON → DocumentAST with correct fields."""
+        ds = _structurer()
+        ds._gemini_client.generate_content.return_value = MagicMock(text=_VALID_RESPONSE)
+
+        result = ds.structure(_make_blocks())
+
+        assert isinstance(result, DocumentAST)
+        assert result.title == "Test Document"
+        assert result.authors == ["Alice"]
+        assert result.abstract == "An abstract."
+        assert len(result.sections) == 1
+        assert result.sections[0].heading == "Introduction"
+        assert result.sections[0].content == ["First paragraph.", "Second paragraph."]
+
+    def test_markdown_fences_are_stripped(self):
+        """Markdown-fenced JSON response is parsed correctly."""
+        ds = _structurer()
+        ds._gemini_client.generate_content.return_value = MagicMock(text=_FENCED_RESPONSE)
+
+        result = ds.structure(_make_blocks())
+
+        assert isinstance(result, DocumentAST)
+        assert result.title == "Test Document"
+
+    def test_nested_subsections_are_parsed(self):
+        """Subsections are recursively converted to Section objects."""
+        response = json.dumps(
+            {
+                "title": "Doc",
+                "authors": [],
+                "abstract": None,
+                "sections": [
+                    {
+                        "heading": "Top",
+                        "level": 1,
+                        "content": [],
+                        "tables": [],
+                        "images": [],
+                        "subsections": [
+                            {
+                                "heading": "Sub",
+                                "level": 2,
+                                "content": ["text"],
+                                "tables": [],
+                                "images": [],
+                                "subsections": [],
+                            }
+                        ],
+                    }
+                ],
+                "metadata": {},
+            }
+        )
+        ds = _structurer()
+        ds._gemini_client.generate_content.return_value = MagicMock(text=response)
+
+        result = ds.structure(_make_blocks())
+
+        assert result.sections[0].subsections[0].heading == "Sub"
+        assert result.sections[0].subsections[0].level == 2
+
+
+class TestGeminiFallbackToGroq:
+    def test_gemini_fallback_to_groq(self):
+        """When Gemini fails all retries, Groq is called and returns a valid AST."""
+        ds = _structurer()
+        ds._gemini_client.generate_content.side_effect = Exception("Gemini down")
+        ds._groq_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=_VALID_RESPONSE))]
+        )
+
+        with patch("time.sleep"):
+            result = ds.structure(_make_blocks())
+
+        assert isinstance(result, DocumentAST)
+        assert result.title == "Test Document"
+        assert ds._groq_client.chat.completions.create.called
+
+    def test_groq_not_called_when_gemini_succeeds(self):
+        """Groq must not be invoked when Gemini succeeds on the first attempt."""
+        ds = _structurer()
+        ds._gemini_client.generate_content.return_value = MagicMock(text=_VALID_RESPONSE)
+
+        ds.structure(_make_blocks())
+
+        ds._groq_client.chat.completions.create.assert_not_called()
+
+
+class TestInvalidJsonTriggersRetry:
+    def test_invalid_json_triggers_retry(self):
+        """First call returns invalid JSON; second call returns valid JSON. Gemini called twice."""
+        ds = _structurer()
+        ds._gemini_client.generate_content.side_effect = [
+            MagicMock(text="not valid json at all"),
+            MagicMock(text=_VALID_RESPONSE),
+        ]
+
+        with patch("time.sleep") as mock_sleep:
+            result = ds.structure(_make_blocks())
+
+        assert isinstance(result, DocumentAST)
+        assert ds._gemini_client.generate_content.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    def test_strict_prompt_used_on_retry(self):
+        """The stricter prompt suffix is appended on the second attempt."""
+        from docstream.core.structurer import _STRICT_SUFFIX
+
+        ds = _structurer()
+        received_prompts: list[str] = []
+
+        def capture(prompt: str) -> MagicMock:
+            received_prompts.append(prompt)
+            if len(received_prompts) == 1:
+                return MagicMock(text="bad json")
+            return MagicMock(text=_VALID_RESPONSE)
+
+        ds._gemini_client.generate_content.side_effect = capture
+
+        with patch("time.sleep"):
+            ds.structure(_make_blocks())
+
+        assert _STRICT_SUFFIX not in received_prompts[0]
+        assert received_prompts[1].endswith(_STRICT_SUFFIX)
+
+
+class TestMissingApiKeyRaisesError:
+    def test_missing_api_key_raises_error(self):
+        """Empty keys → no clients → StructuringError on structure()."""
+        with patch("docstream.core.structurer.genai"):
+            with patch("docstream.core.structurer.Groq"):
+                ds = DocumentStructurer(gemini_key="", groq_key=None)
+
+        with pytest.raises(StructuringError, match="No AI provider available"):
+            ds.structure(_make_blocks())
+
+    def test_groq_only_works_without_gemini(self):
+        """Groq-only setup (no Gemini key) falls through to Groq successfully."""
+        with patch("docstream.core.structurer.genai"):
+            with patch("docstream.core.structurer.Groq"):
+                ds = DocumentStructurer(gemini_key="", groq_key="fake-groq")
+        ds._groq_client = MagicMock()
+        ds._groq_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=_VALID_RESPONSE))]
+        )
+
+        result = ds.structure(_make_blocks())
 
         assert isinstance(result, DocumentAST)
 
-    @patch("docstream.core.structurer.genai")
-    def test_structure_creates_sections(self, mock_genai, sample_raw_content):
-        """GeminiStructurer should produce at least one section."""
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = MOCK_AI_RESPONSE
-        mock_genai.GenerativeModel.return_value = mock_model
 
-        structurer = GeminiStructurer(api_key="fake_key")
-        result = structurer.structure(sample_raw_content)
+class TestPromptTruncationForLargeDocuments:
+    def test_prompt_truncation_for_large_documents(self):
+        """A document whose blocks exceed _MAX_CONTENT_CHARS is truncated in the prompt."""
+        char_per_block = 1000
+        n_blocks = (_MAX_CONTENT_CHARS // char_per_block) + 10
+        large_blocks = [
+            TextBlock(type=BlockType.TEXT, content="x" * char_per_block) for _ in range(n_blocks)
+        ]
 
-        assert len(result.sections) >= 1
+        ds = _structurer()
+        prompt = ds._build_prompt(large_blocks)
 
-    @patch("docstream.core.structurer.genai")
-    def test_structure_raises_on_invalid_response(self, mock_genai, sample_raw_content):
-        """GeminiStructurer should raise StructuringError for non-JSON responses."""
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = "not valid json at all"
-        mock_genai.GenerativeModel.return_value = mock_model
+        assert "[...document truncated to fit token limit...]" in prompt
 
-        structurer = GeminiStructurer(api_key="fake_key")
-        with pytest.raises(StructuringError):
-            structurer.structure(sample_raw_content)
+    def test_prompt_within_limit_for_small_documents(self):
+        """Small documents are not truncated."""
+        ds = _structurer()
+        prompt = ds._build_prompt(_make_blocks(5))
 
-    @patch("docstream.core.structurer.genai")
-    def test_structure_propagates_metadata(self, mock_genai, sample_raw_content):
-        """Structured DocumentAST should carry the original metadata."""
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value.text = MOCK_AI_RESPONSE
-        mock_genai.GenerativeModel.return_value = mock_model
+        assert "[...document truncated" not in prompt
 
-        structurer = GeminiStructurer(api_key="fake_key")
-        result = structurer.structure(sample_raw_content)
+    def test_prompt_contains_font_size_hints(self):
+        """Blocks with font_size metadata include the hint in the prompt."""
+        block = TextBlock(
+            type=BlockType.TEXT,
+            content="A heading",
+            metadata={"font_size": 18},
+        )
+        ds = _structurer()
+        prompt = ds._build_prompt([block])
 
-        assert result.metadata == sample_raw_content.metadata
-
-
-class TestGroqStructurer:
-    """Unit tests for GroqStructurer."""
-
-    @patch("docstream.core.structurer.Groq")
-    def test_structure_returns_document_ast(self, mock_groq_cls, sample_raw_content):
-        """GroqStructurer.structure should return a DocumentAST."""
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value.choices[
-            0
-        ].message.content = MOCK_AI_RESPONSE
-        mock_groq_cls.return_value = mock_client
-
-        structurer = GroqStructurer(api_key="fake_key")
-        result = structurer.structure(sample_raw_content)
-
-        assert isinstance(result, DocumentAST)
-
-    @patch("docstream.core.structurer.Groq")
-    def test_structure_raises_on_api_error(self, mock_groq_cls, sample_raw_content):
-        """GroqStructurer should raise StructuringError when API call fails."""
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.side_effect = Exception("API error")
-        mock_groq_cls.return_value = mock_client
-
-        structurer = GroqStructurer(api_key="fake_key")
-        with pytest.raises(StructuringError):
-            structurer.structure(sample_raw_content)
-
-
-class TestStructurer:
-    """Unit tests for the main Structurer dispatcher."""
-
-    def test_raises_when_no_models_configured(self, sample_raw_content):
-        """Structurer with no API keys should raise StructuringError."""
-        structurer = Structurer()  # no API keys
-        with pytest.raises(StructuringError):
-            structurer.structure(sample_raw_content)
-
-    def test_get_available_models_empty(self):
-        """No API keys → no available models."""
-        structurer = Structurer()
-        assert structurer.get_available_models() == []
-
-    @patch("docstream.core.structurer.genai")
-    def test_get_available_models_with_gemini(self, mock_genai):
-        """Gemini key present → 'gemini' in available models."""
-        mock_genai.GenerativeModel.return_value = MagicMock()
-        structurer = Structurer(gemini_api_key="fake_key")
-        assert "gemini" in structurer.get_available_models()
-
-    @patch("docstream.core.structurer.Groq")
-    def test_set_preferred_model(self, mock_groq_cls):
-        """set_preferred_model should update the preferred model."""
-        mock_groq_cls.return_value = MagicMock()
-        structurer = Structurer(groq_api_key="fake_key", preferred_model="groq")
-        structurer.set_preferred_model("groq")
-        assert structurer.preferred_model == "groq"
-
-    def test_set_preferred_model_raises_for_unavailable(self):
-        """set_preferred_model should raise ValueError for unknown models."""
-        structurer = Structurer()
-        with pytest.raises(ValueError):
-            structurer.set_preferred_model("nonexistent_model")
-
-    @patch("docstream.core.structurer.genai")
-    def test_falls_back_to_secondary_model(self, mock_genai, sample_raw_content):
-        """Structurer should fall back to groq when gemini fails."""
-        # Gemini raises, groq succeeds
-        mock_model = MagicMock()
-        mock_model.generate_content.side_effect = Exception("Gemini down")
-        mock_genai.GenerativeModel.return_value = mock_model
-
-        with patch("docstream.core.structurer.Groq") as mock_groq_cls:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value.choices[
-                0
-            ].message.content = MOCK_AI_RESPONSE
-            mock_groq_cls.return_value = mock_client
-
-            structurer = Structurer(
-                gemini_api_key="fake_gemini",
-                groq_api_key="fake_groq",
-                preferred_model="gemini",
-            )
-            result = structurer.structure(sample_raw_content)
-            assert isinstance(result, DocumentAST)
+        assert "[font_size=18]" in prompt


### PR DESCRIPTION
- implement DocumentStructurer class with gemini_key / groq_key init
- use Gemini 1.5 Flash (free tier) as primary provider
- use Groq llama-3.1-70b-versatile as fallback
- fallback chain: Gemini (2 retries) -> Groq (2 retries) -> StructuringError
- exponential backoff: 1s, 2s per retry; stricter prompt on 2nd attempt
- _build_prompt: font_size hints, example JSON, truncates at ~8000 tokens
- _parse_response: strips markdown fences, validates with _validate_ast
- _dict_to_ast / _dict_to_section: recursive DocumentAST construction
- load API keys from .env via python-dotenv (never hardcoded)
- add Structurer alias for backward compatibility
- rewrite test_structurer.py: 13 tests across 5 classes, all mocked, all passing