### PR TITLE
feat: phase 3 — document renderer with Pandoc + XeLaTeX

### DIFF
--- a/docstream/core/renderer.py
+++ b/docstream/core/renderer.py
@@ -5,17 +5,21 @@ The Renderer class handles conversion of DocumentAST to target formats
 using Lua templates and LaTeX compilation.
 """
 
+import json
 import logging
 import os
 import re
+import shutil
 import subprocess
+import tempfile
+import time
 from abc import ABC, abstractmethod
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 from docstream.exceptions import RenderingError
-from docstream.models.document import DocumentAST
+from docstream.models.document import ConversionResult, DocumentAST, Section
 
 logger = logging.getLogger(__name__)
 
@@ -415,3 +419,215 @@ class Renderer:
             return True
         except Exception:
             return False
+
+
+# ---------------------------------------------------------------------------
+# Phase-3: DocumentRenderer
+# ---------------------------------------------------------------------------
+
+_VALID_TEMPLATES = {"report", "ieee", "resume"}
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+
+
+class DocumentRenderer:
+    """Render a DocumentAST to .tex and .pdf via Pandoc + XeLaTeX."""
+
+    VALID_TEMPLATES = _VALID_TEMPLATES
+
+    def __init__(self, template: str = "report") -> None:
+        if template not in _VALID_TEMPLATES:
+            raise ValueError(
+                f"Unknown template '{template}'. Must be one of {sorted(_VALID_TEMPLATES)}"
+            )
+        self.template = template
+        self._template_dir = _TEMPLATES_DIR
+        self._check_pandoc()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def render(self, ast: DocumentAST, output_dir: Path) -> ConversionResult:
+        """Convert *ast* to .tex and .pdf inside *output_dir*."""
+        start = time.monotonic()
+        tmp_dir = Path(tempfile.mkdtemp(prefix="docstream_render_"))
+        try:
+            output_dir = Path(output_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            pandoc_json = self._ast_to_pandoc_json(ast)
+            tex_content = self._run_pandoc(pandoc_json, self.template)
+
+            tex_path = output_dir / "document.tex"
+            tex_path.write_text(tex_content, encoding="utf-8")
+
+            pdf_path = self._compile_latex(tex_content, output_dir)
+
+            elapsed = time.monotonic() - start
+            logger.info("Rendered '%s' template in %.2fs → %s", self.template, elapsed, pdf_path)
+            return ConversionResult(
+                success=True,
+                tex_path=tex_path,
+                pdf_path=pdf_path,
+                processing_time_seconds=elapsed,
+                template_used=self.template,
+            )
+        except Exception as exc:  # noqa: BLE001
+            elapsed = time.monotonic() - start
+            logger.error("Rendering failed: %s", exc)
+            return ConversionResult(
+                success=False,
+                error=str(exc),
+                processing_time_seconds=elapsed,
+                template_used=self.template,
+            )
+        finally:
+            self._cleanup(tmp_dir)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_pandoc(self) -> None:
+        """Raise RenderingError when pandoc is not installed."""
+        try:
+            subprocess.run(
+                ["pandoc", "--version"],
+                capture_output=True,
+                check=True,
+                timeout=10,
+            )
+        except FileNotFoundError as exc:
+            raise RenderingError("Pandoc not found. Install from pandoc.org") from exc
+        except subprocess.CalledProcessError as exc:
+            raise RenderingError(f"Pandoc version check failed: {exc}") from exc
+
+    def _ast_to_pandoc_json(self, ast: DocumentAST) -> dict[str, Any]:
+        """Convert *DocumentAST* to a valid Pandoc native JSON dict."""
+
+        def _inlines(text: str) -> list[dict]:
+            nodes: list[dict] = []
+            for i, word in enumerate(text.split(" ")):
+                if word:
+                    nodes.append({"t": "Str", "c": word})
+                if i < len(text.split(" ")) - 1:
+                    nodes.append({"t": "Space"})
+            return nodes
+
+        def _section_blocks(section: Section) -> list[dict]:
+            blocks: list[dict] = []
+            attr = [section.heading.lower().replace(" ", "-"), [], []]
+            blocks.append({"t": "Header", "c": [section.level, attr, _inlines(section.heading)]})
+            for para in section.content:
+                if para.strip():
+                    blocks.append({"t": "Para", "c": _inlines(para)})
+            for table in section.tables:
+                caption = table.caption or ""
+                blocks.append(
+                    {"t": "Para", "c": _inlines(f"[Table{': ' + caption if caption else ''}]")}
+                )
+            for sub in section.subsections:
+                blocks.extend(_section_blocks(sub))
+            return blocks
+
+        pandoc_blocks: list[dict] = []
+        if ast.title:
+            pandoc_blocks.append(
+                {"t": "Header", "c": [1, ["doc-title", [], []], _inlines(ast.title)]}
+            )
+        if ast.abstract:
+            pandoc_blocks.append({"t": "Para", "c": _inlines(ast.abstract)})
+        for section in ast.sections:
+            pandoc_blocks.extend(_section_blocks(section))
+
+        meta: dict[str, Any] = {}
+        if ast.title:
+            meta["title"] = {"t": "MetaInlines", "c": _inlines(ast.title)}
+        if ast.authors:
+            meta["author"] = {
+                "t": "MetaList",
+                "c": [{"t": "MetaInlines", "c": _inlines(a)} for a in ast.authors],
+            }
+
+        return {
+            "pandoc-api-version": [1, 23, 1],
+            "meta": meta,
+            "blocks": pandoc_blocks,
+        }
+
+    def _run_pandoc(self, pandoc_json: dict[str, Any], template: str) -> str:
+        """Run pandoc to convert Pandoc JSON → LaTeX using the Lua writer."""
+        tmp_dir = Path(tempfile.mkdtemp(prefix="docstream_pandoc_"))
+        try:
+            json_file = tmp_dir / "input.json"
+            json_file.write_text(json.dumps(pandoc_json), encoding="utf-8")
+
+            lua_path = self._template_dir / f"{template}.lua"
+            result = subprocess.run(
+                ["pandoc", "-f", "json", "-t", str(lua_path), str(json_file)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                raise RenderingError(f"Pandoc failed:\n{result.stderr.strip()}")
+            return result.stdout
+        except FileNotFoundError as exc:
+            raise RenderingError("Pandoc not found. Install from pandoc.org") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RenderingError("Pandoc timed out (>60 s)") from exc
+        finally:
+            self._cleanup(tmp_dir)
+
+    def _compile_latex(self, tex_content: str, output_dir: Path) -> Path:
+        """Compile *tex_content* to PDF with xelatex (run twice for cross-refs)."""
+        tmp_dir = Path(tempfile.mkdtemp(prefix="docstream_xelatex_"))
+        try:
+            tex_file = tmp_dir / "document.tex"
+            tex_file.write_text(tex_content, encoding="utf-8")
+
+            cmd = ["xelatex", "-interaction=nonstopmode", "document.tex"]
+            for _run in range(2):
+                result = subprocess.run(
+                    cmd,
+                    cwd=str(tmp_dir),
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                if result.returncode != 0:
+                    error_msg = self._parse_latex_log(tmp_dir / "document.log", result.stderr)
+                    raise RenderingError(f"LaTeX compilation failed: {error_msg}")
+
+            pdf_src = tmp_dir / "document.pdf"
+            if not pdf_src.exists():
+                raise RenderingError("xelatex ran but produced no PDF file")
+
+            pdf_dest = output_dir / "document.pdf"
+            shutil.copy2(str(pdf_src), str(pdf_dest))
+            return pdf_dest
+        except subprocess.TimeoutExpired as exc:
+            raise RenderingError("xelatex compilation timed out (>60 s)") from exc
+        finally:
+            self._cleanup(tmp_dir)
+
+    def _parse_latex_log(self, log_file: Path, fallback: str) -> str:
+        """Extract lines starting with '!' from the xelatex .log file."""
+        if log_file.exists():
+            errors = [
+                line
+                for line in log_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+                if line.startswith("!")
+            ]
+            if errors:
+                return "\n".join(errors)
+        return fallback.strip() or "Unknown LaTeX error"
+
+    def _cleanup(self, tmp_dir: Path) -> None:
+        """Recursively remove *tmp_dir*, ignoring errors."""
+        if tmp_dir and tmp_dir.exists():
+            try:
+                shutil.rmtree(str(tmp_dir))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Cleanup failed for %s: %s", tmp_dir, exc)

--- a/docstream/models/document.py
+++ b/docstream/models/document.py
@@ -8,6 +8,7 @@ content blocks, and conversion results.
 import uuid
 from datetime import datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -328,6 +329,8 @@ class RawContent(BaseModel):
 class ConversionResult(BaseModel):
     """Result of document conversion operations."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     success: bool
     content: str | None = None  # LaTeX or text content
     pdf_content: bytes | None = None  # PDF bytes
@@ -335,6 +338,13 @@ class ConversionResult(BaseModel):
     errors: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     processing_time: float | None = None
+
+    # Phase 3 fields
+    tex_path: Path | None = None
+    pdf_path: Path | None = None
+    error: str | None = None
+    processing_time_seconds: float = 0.0
+    template_used: str = ""
 
     def save(self, output_path: str) -> bool:
         """Save the result to a file.

--- a/docstream/templates/ieee.lua
+++ b/docstream/templates/ieee.lua
@@ -1,174 +1,104 @@
--- IEEE Template for Academic Papers
--- Compatible with IEEE conference and journal formats
+-- Pandoc Lua custom writer: IEEE two-column conference format
+-- IEEEtran class, two-column layout
 
-local template = {
-    name = "IEEE Template",
-    description = "IEEE academic paper template for conferences and journals",
-    version = "1.0.0",
-    author = "DocStream Team",
-    dependencies = {"IEEEconf", "graphicx", "amsmath", "url", "booktabs"}
-}
-
-function template.render(document)
-    local latex = {}
-    
-    -- Document class and packages
-    table.insert(latex, "\\documentclass[conference]{IEEEconf}")
-    table.insert(latex, "\\IEEEoverridecommandlockouts")
-    table.insert(latex, "\\IEEEoverridecommandlockouts")
-    table.insert(latex, "\\IEEEstartofpreamble")
-    
-    -- Required packages
-    table.insert(latex, "\\usepackage{cite}")
-    table.insert(latex, "\\usepackage{amsmath,amssymb,amsfonts}")
-    table.insert(latex, "\\usepackage{algorithmic}")
-    table.insert(latex, "\\usepackage{graphicx}")
-    table.insert(latex, "\\usepackage{textcomp}")
-    table.insert(latex, "\\usepackage{xcolor}")
-    table.insert(latex, "\\usepackage{url}")
-    table.insert(latex, "\\usepackage{booktabs}")
-    
-    -- Document setup
-    table.insert(latex, "\\def\\IEEEbibitemsep{1pt}")
-    table.insert(latex, "\\IEEEoverridecommandlockouts")
-    table.insert(latex, "\\IEEEstartofpreamble")
-    
-    -- Title and authors
-    if document.metadata.title then
-        table.insert(latex, "\\title{" .. escape_latex(document.metadata.title) .. "}")
-    end
-    
-    if document.metadata.author then
-        table.insert(latex, "\\author{\\IEEEauthorblockN{" .. escape_latex(document.metadata.author) .. "}}")
-    end
-    
-    table.insert(latex, "\\IEEEendofpreamble")
-    table.insert(latex, "\\begin{document}")
-    
-    -- Title
-    table.insert(latex, "\\maketitle")
-    
-    -- Abstract
-    if document.metadata.abstract then
-        table.insert(latex, "\\begin{abstract}")
-        table.insert(latex, escape_latex(document.metadata.abstract))
-        table.insert(latex, "\\end{abstract}")
-    end
-    
-    -- Keywords
-    if document.metadata.keywords and #document.metadata.keywords > 0 then
-        table.insert(latex, "\\begin{IEEEkeywords}")
-        table.insert(latex, table.concat(document.metadata.keywords, ", "))
-        table.insert(latex, "\\end{IEEEkeywords}")
-    end
-    
-    -- Main content
-    for _, section in ipairs(document.sections) do
-        table.insert(latex, render_section(section))
-    end
-    
-    -- References
-    table.insert(latex, "\\begin{thebibliography}{99}")
-    table.insert(latex, "\\end{thebibliography}")
-    
-    table.insert(latex, "\\end{document}")
-    
-    return table.concat(latex, "\n")
-end
-
-function template.render_section(section)
-    local content = {}
-    
-    -- Section heading
-    if section.level == 1 then
-        table.insert(content, "\\section{" .. escape_latex(section.title) .. "}")
-    elseif section.level == 2 then
-        table.insert(content, "\\subsection{" .. escape_latex(section.title) .. "}")
-    elseif section.level == 3 then
-        table.insert(content, "\\subsubsection{" .. escape_latex(section.title) .. "}")
-    else
-        table.insert(content, "\\paragraph{" .. escape_latex(section.title) .. "}")
-    end
-    
-    -- Section content
-    for _, block in ipairs(section.blocks) do
-        table.insert(content, render_block(block))
-    end
-    
-    return table.concat(content, "\n")
-end
-
-function template.render_block(block)
-    if block.type == "text" then
-        return escape_latex(block.content) .. "\n\n"
-    elseif block.type == "heading" then
-        if block.level == 4 then
-            return "\\paragraph{" .. escape_latex(block.content) .. "}\n\n"
-        else
-            return escape_latex(block.content) .. "\n\n"
-        end
-    elseif block.type == "list" then
-        return render_list(block)
-    elseif block.type == "code" then
-        return render_code(block)
-    elseif block.type == "quote" then
-        return "\\begin{quote}\n" .. escape_latex(block.content) .. "\n\\end{quote}\n\n"
-    else
-        return escape_latex(block.content) .. "\n\n"
-    end
-end
-
-function template.render_list(block)
-    local content = {}
-    
-    if block.ordered then
-        table.insert(content, "\\begin{enumerate}")
-    else
-        table.insert(content, "\\begin{itemize}")
-    end
-    
-    for _, item in ipairs(block.items or {}) do
-        table.insert(content, "\\item " .. escape_latex(item))
-    end
-    
-    if block.ordered then
-        table.insert(content, "\\end{enumerate}")
-    else
-        table.insert(content, "\\end{itemize}")
-    end
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_code(block)
-    local content = {}
-    table.insert(content, "\\begin{verbatim}")
-    table.insert(content, block.content)
-    table.insert(content, "\\end{verbatim}")
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.escape_latex(text)
+local function escape(text)
     if not text then return "" end
-    
-    local latex_special_chars = {
-        ["&"] = "\\&",
-        ["%"] = "\\%",
-        ["$"] = "\\$",
-        ["#"] = "\\#",
-        ["_"] = "\\_",
-        ["{"] = "\\{",
-        ["}"] = "\\}",
-        ["~"] = "\\textasciitilde{}",
-        ["^"] = "\\^{}",
-        ["\\"] = "\\textbackslash{}",
-    }
-    
-    for char, escaped in pairs(latex_special_chars) do
-        text = string.gsub(text, char, escaped)
-    end
-    
+    text = text:gsub("\\", "\\textbackslash{}")
+    text = text:gsub("%%", "\\%%")
+    text = text:gsub("%$", "\\$")
+    text = text:gsub("&",  "\\&")
+    text = text:gsub("#",  "\\#")
+    text = text:gsub("_",  "\\_")
+    text = text:gsub("{",  "\\{")
+    text = text:gsub("}",  "\\}")
+    text = text:gsub("~",  "\\textasciitilde{}")
+    text = text:gsub("%^", "\\^{}")
     return text
 end
 
-return template
+local function write_inlines(inlines)
+    local parts = {}
+    for _, il in ipairs(inlines) do
+        if     il.t == "Str"       then table.insert(parts, escape(il.c))
+        elseif il.t == "Space"     then table.insert(parts, " ")
+        elseif il.t == "SoftBreak" then table.insert(parts, " ")
+        elseif il.t == "LineBreak" then table.insert(parts, "\\\\\n")
+        elseif il.t == "Strong"    then table.insert(parts, "\\textbf{" .. write_inlines(il.c) .. "}")
+        elseif il.t == "Emph"      then table.insert(parts, "\\emph{"   .. write_inlines(il.c) .. "}")
+        elseif il.t == "Code"      then table.insert(parts, "\\texttt{" .. escape(il.c[2])    .. "}")
+        elseif type(il.c) == "string" then table.insert(parts, escape(il.c))
+        end
+    end
+    return table.concat(parts)
+end
+
+local function write_block(block)
+    if block.t == "Header" then
+        local lvl  = block.c[1]
+        local text = write_inlines(block.c[3])
+        if     lvl == 1 then return "\\section{"       .. text .. "}\n"
+        elseif lvl == 2 then return "\\subsection{"    .. text .. "}\n"
+        elseif lvl == 3 then return "\\subsubsection{" .. text .. "}\n"
+        else                  return "\\paragraph{"    .. text .. "}\n"
+        end
+    elseif block.t == "Para" then
+        return write_inlines(block.c) .. "\n\n"
+    elseif block.t == "Plain" then
+        return write_inlines(block.c) .. "\n"
+    elseif block.t == "BlockQuote" then
+        local inner = {}
+        for _, b in ipairs(block.c) do table.insert(inner, write_block(b)) end
+        return "\\begin{quote}\n" .. table.concat(inner) .. "\\end{quote}\n\n"
+    elseif block.t == "CodeBlock" then
+        return "\\begin{verbatim}\n" .. block.c[2] .. "\n\\end{verbatim}\n\n"
+    elseif block.t == "BulletList" then
+        local items = {"\\begin{itemize}"}
+        for _, item in ipairs(block.c) do
+            local blocks = {}
+            for _, b in ipairs(item) do table.insert(blocks, write_block(b)) end
+            table.insert(items, "\\item " .. table.concat(blocks))
+        end
+        table.insert(items, "\\end{itemize}\n")
+        return table.concat(items, "\n")
+    elseif block.t == "HorizontalRule" then
+        return "\\hrule\n\n"
+    else
+        return ""
+    end
+end
+
+function Writer(doc, opts)
+    local out  = {}
+    local meta = doc.meta
+
+    table.insert(out, "\\documentclass[conference,10pt]{IEEEtran}")
+    table.insert(out, "\\usepackage[T1]{fontenc}")
+    table.insert(out, "\\usepackage{cite}")
+    table.insert(out, "\\usepackage{amsmath,amssymb}")
+    table.insert(out, "\\usepackage{graphicx}")
+    table.insert(out, "\\usepackage{booktabs}")
+    table.insert(out, "\\usepackage{microtype}")
+
+    local title  = meta.title  and pandoc.utils.stringify(meta.title)  or ""
+    local author = meta.author and pandoc.utils.stringify(meta.author) or ""
+
+    if title  ~= "" then table.insert(out, "\\title{"  .. escape(title)  .. "}") end
+    if author ~= "" then table.insert(out, "\\author{\\IEEEauthorblockN{" .. escape(author) .. "}}") end
+
+    table.insert(out, "\\begin{document}")
+    if title ~= "" then table.insert(out, "\\maketitle") end
+
+    if meta.abstract then
+        local abs_text = pandoc.utils.stringify(meta.abstract)
+        table.insert(out, "\\begin{abstract}")
+        table.insert(out, escape(abs_text))
+        table.insert(out, "\\end{abstract}")
+    end
+
+    for _, block in ipairs(doc.blocks) do
+        table.insert(out, write_block(block))
+    end
+
+    table.insert(out, "\\end{document}")
+    return table.concat(out, "\n")
+end

--- a/docstream/templates/report.lua
+++ b/docstream/templates/report.lua
@@ -1,268 +1,107 @@
--- Report Template for Technical Documents
--- Suitable for technical reports, documentation, and internal papers
+-- Pandoc Lua custom writer: academic report template
+-- article class, 1in margins, serif font (lmodern)
 
-local template = {
-    name = "Report Template",
-    description = "Technical report template with standard formatting",
-    version = "1.0.0",
-    author = "DocStream Team",
-    dependencies = {"geometry", "fancyhdr", "hyperref", "graphicx", "booktabs", "times"}
-}
-
-function template.render(document)
-    local latex = {}
-    
-    -- Document class and packages
-    table.insert(latex, "\\documentclass[11pt,a4paper]{report}")
-    
-    -- Page geometry
-    table.insert(latex, "\\usepackage[margin=1in,top=1in,bottom=1in]{geometry}")
-    
-    -- Fonts and text
-    table.insert(latex, "\\usepackage{times}")
-    table.insert(latex, "\\usepackage[T1]{fontenc}")
-    
-    -- Headers and footers
-    table.insert(latex, "\\usepackage{fancyhdr}")
-    table.insert(latex, "\\pagestyle{fancy}")
-    table.insert(latex, "\\fancyhf{}")
-    table.insert(latex, "\\fancyhead[L]{" .. (document.metadata.title or "Document") .. "}")
-    table.insert(latex, "\\fancyhead[R]{\\today}")
-    table.insert(latex, "\\fancyfoot[C]{\\thepage}")
-    
-    -- Hyperlinks
-    table.insert(latex, "\\usepackage{hyperref}")
-    table.insert(latex, "\\hypersetup{colorlinks=true,linkcolor=blue,urlcolor=blue}")
-    
-    -- Graphics and tables
-    table.insert(latex, "\\usepackage{graphicx}")
-    table.insert(latex, "\\usepackage{booktabs}")
-    table.insert(latex, "\\usepackage{float}")
-    
-    -- Math and symbols
-    table.insert(latex, "\\usepackage{amsmath}")
-    table.insert(latex, "\\usepackage{amssymb}")
-    
-    -- Lists and formatting
-    table.insert(latex, "\\usepackage{enumitem}")
-    table.insert(latex, "\\usepackage{verbatim}")
-    
-    -- Document information
-    table.insert(latex, "\\title{" .. escape_latex(document.metadata.title or "Technical Report") .. "}")
-    
-    if document.metadata.author then
-        table.insert(latex, "\\author{" .. escape_latex(document.metadata.author) .. "}")
-    end
-    
-    table.insert(latex, "\\date{" .. (document.metadata.date or "\\today") .. "}")
-    
-    table.insert(latex, "\\begin{document}")
-    
-    -- Title page
-    table.insert(latex, "\\maketitle")
-    
-    -- Table of contents
-    table.insert(latex, "\\tableofcontents")
-    table.insert(latex, "\\newpage")
-    
-    -- Abstract
-    if document.metadata.abstract then
-        table.insert(latex, "\\begin{abstract}")
-        table.insert(latex, escape_latex(document.metadata.abstract))
-        table.insert(latex, "\\end{abstract}")
-        table.insert(latex, "\\newpage")
-    end
-    
-    -- Main content
-    for _, section in ipairs(document.sections) do
-        table.insert(latex, render_section(section))
-    end
-    
-    -- Appendices (if any)
-    if document.metadata.appendices then
-        table.insert(latex, "\\appendix")
-        for _, appendix in ipairs(document.metadata.appendices) do
-            table.insert(latex, "\\chapter{" .. escape_latex(appendix.title) .. "}")
-            table.insert(latex, escape_latex(appendix.content))
-        end
-    end
-    
-    -- Bibliography
-    table.insert(latex, "\\begin{thebibliography}{99}")
-    table.insert(latex, "\\end{thebibliography}")
-    
-    table.insert(latex, "\\end{document}")
-    
-    return table.concat(latex, "\n")
-end
-
-function template.render_section(section)
-    local content = {}
-    
-    -- Section heading with appropriate level
-    if section.level == 1 then
-        table.insert(content, "\\chapter{" .. escape_latex(section.title) .. "}")
-    elseif section.level == 2 then
-        table.insert(content, "\\section{" .. escape_latex(section.title) .. "}")
-    elseif section.level == 3 then
-        table.insert(content, "\\subsection{" .. escape_latex(section.title) .. "}")
-    elseif section.level == 4 then
-        table.insert(content, "\\subsubsection{" .. escape_latex(section.title) .. "}")
-    else
-        table.insert(content, "\\paragraph{" .. escape_latex(section.title) .. "}")
-    end
-    
-    -- Add label for cross-referencing
-    local label = string.gsub(section.title, "%s+", "_")
-    label = string.gsub(label, "[^%w_]", "")
-    table.insert(content, "\\label{sec:" .. label .. "}")
-    
-    -- Section content
-    for _, block in ipairs(section.blocks) do
-        table.insert(content, render_block(block))
-    end
-    
-    return table.concat(content, "\n")
-end
-
-function template.render_block(block)
-    if block.type == "text" then
-        return escape_latex(block.content) .. "\n\n"
-    elseif block.type == "heading" then
-        if block.level == 5 then
-            return "\\subparagraph{" .. escape_latex(block.content) .. "}\n\n"
-        else
-            return escape_latex(block.content) .. "\n\n"
-        end
-    elseif block.type == "list" then
-        return render_list(block)
-    elseif block.type == "code" then
-        return render_code(block)
-    elseif block.type == "quote" then
-        return "\\begin{quote}\n" .. escape_latex(block.content) .. "\n\\end{quote}\n\n"
-    elseif block.type == "table" then
-        return render_table(block)
-    elseif block.type == "image" then
-        return render_image(block)
-    else
-        return escape_latex(block.content) .. "\n\n"
-    end
-end
-
-function template.render_list(block)
-    local content = {}
-    
-    if block.ordered then
-        table.insert(content, "\\begin{enumerate}[label=\\arabic*.]")
-    else
-        table.insert(content, "\\begin{itemize}")
-    end
-    
-    for _, item in ipairs(block.items or {}) do
-        table.insert(content, "\\item " .. escape_latex(item))
-    end
-    
-    if block.ordered then
-        table.insert(content, "\\end{enumerate}")
-    else
-        table.insert(content, "\\end{itemize}")
-    end
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_code(block)
-    local content = {}
-    
-    if block.language and block.language ~= "" then
-        table.insert(content, "\\textbf{" .. block.language .. " Code:}")
-    end
-    
-    table.insert(content, "\\begin{verbatim}")
-    table.insert(content, block.content)
-    table.insert(content, "\\end{verbatim}")
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_table(block)
-    local content = {}
-    table.insert(content, "\\begin{table}[H]")
-    table.insert(content, "\\centering")
-    
-    if block.caption then
-        table.insert(content, "\\caption{" .. escape_latex(block.caption) .. "}")
-    end
-    
-    table.insert(content, "\\begin{tabular}{" .. string.rep("l", #block.headers) .. "}")
-    table.insert(content, "\\toprule")
-    
-    -- Headers
-    local header_row = {}
-    for _, header in ipairs(block.headers or {}) do
-        table.insert(header_row, escape_latex(header))
-    end
-    table.insert(content, table.concat(header_row, " & ") .. " \\\\")
-    table.insert(content, "\\midrule")
-    
-    -- Data rows
-    for _, row in ipairs(block.rows or {}) do
-        local row_content = {}
-        for _, cell in ipairs(row) do
-            table.insert(row_content, escape_latex(cell))
-        end
-        table.insert(content, table.concat(row_content, " & ") .. " \\\\")
-    end
-    
-    table.insert(content, "\\bottomrule")
-    table.insert(content, "\\end{tabular}")
-    table.insert(content, "\\end{table}")
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_image(block)
-    local content = {}
-    table.insert(content, "\\begin{figure}[H]")
-    table.insert(content, "\\centering")
-    
-    local width = "\\textwidth"
-    if block.width then
-        width = block.width
-    end
-    
-    table.insert(content, "\\includegraphics[width=" .. width .. "]{" .. block.src .. "}")
-    
-    if block.caption then
-        table.insert(content, "\\caption{" .. escape_latex(block.caption) .. "}")
-    end
-    
-    table.insert(content, "\\end{figure}")
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.escape_latex(text)
+local function escape(text)
     if not text then return "" end
-    
-    local latex_special_chars = {
-        ["&"] = "\\&",
-        ["%"] = "\\%",
-        ["$"] = "\\$",
-        ["#"] = "\\#",
-        ["_"] = "\\_",
-        ["{"] = "\\{",
-        ["}"] = "\\}",
-        ["~"] = "\\textasciitilde{}",
-        ["^"] = "\\^{}",
-        ["\\"] = "\\textbackslash{}",
-    }
-    
-    for char, escaped in pairs(latex_special_chars) do
-        text = string.gsub(text, char, escaped)
-    end
-    
+    text = text:gsub("\\", "\\textbackslash{}")
+    text = text:gsub("%%", "\\%%")
+    text = text:gsub("%$", "\\$")
+    text = text:gsub("&",  "\\&")
+    text = text:gsub("#",  "\\#")
+    text = text:gsub("_",  "\\_")
+    text = text:gsub("{",  "\\{")
+    text = text:gsub("}",  "\\}")
+    text = text:gsub("~",  "\\textasciitilde{}")
+    text = text:gsub("%^", "\\^{}")
     return text
 end
 
-return template
+local function write_inlines(inlines)
+    local parts = {}
+    for _, il in ipairs(inlines) do
+        if     il.t == "Str"       then table.insert(parts, escape(il.c))
+        elseif il.t == "Space"     then table.insert(parts, " ")
+        elseif il.t == "SoftBreak" then table.insert(parts, " ")
+        elseif il.t == "LineBreak" then table.insert(parts, "\\\\\n")
+        elseif il.t == "Strong"    then table.insert(parts, "\\textbf{" .. write_inlines(il.c) .. "}")
+        elseif il.t == "Emph"      then table.insert(parts, "\\emph{"   .. write_inlines(il.c) .. "}")
+        elseif il.t == "Code"      then table.insert(parts, "\\texttt{" .. escape(il.c[2])    .. "}")
+        elseif type(il.c) == "string" then table.insert(parts, escape(il.c))
+        end
+    end
+    return table.concat(parts)
+end
+
+local function write_block(block)
+    if block.t == "Header" then
+        local lvl  = block.c[1]
+        local text = write_inlines(block.c[3])
+        if     lvl == 1 then return "\\section{"        .. text .. "}\n"
+        elseif lvl == 2 then return "\\subsection{"     .. text .. "}\n"
+        elseif lvl == 3 then return "\\subsubsection{"  .. text .. "}\n"
+        else                  return "\\paragraph{"     .. text .. "}\n"
+        end
+    elseif block.t == "Para" then
+        return write_inlines(block.c) .. "\n\n"
+    elseif block.t == "Plain" then
+        return write_inlines(block.c) .. "\n"
+    elseif block.t == "BlockQuote" then
+        local inner = {}
+        for _, b in ipairs(block.c) do table.insert(inner, write_block(b)) end
+        return "\\begin{quote}\n" .. table.concat(inner) .. "\\end{quote}\n\n"
+    elseif block.t == "CodeBlock" then
+        return "\\begin{verbatim}\n" .. block.c[2] .. "\n\\end{verbatim}\n\n"
+    elseif block.t == "BulletList" then
+        local items = {"\\begin{itemize}"}
+        for _, item in ipairs(block.c) do
+            local blocks = {}
+            for _, b in ipairs(item) do table.insert(blocks, write_block(b)) end
+            table.insert(items, "\\item " .. table.concat(blocks))
+        end
+        table.insert(items, "\\end{itemize}\n")
+        return table.concat(items, "\n")
+    elseif block.t == "OrderedList" then
+        local items = {"\\begin{enumerate}"}
+        for _, item in ipairs(block.c[2]) do
+            local blocks = {}
+            for _, b in ipairs(item) do table.insert(blocks, write_block(b)) end
+            table.insert(items, "\\item " .. table.concat(blocks))
+        end
+        table.insert(items, "\\end{enumerate}\n")
+        return table.concat(items, "\n")
+    elseif block.t == "HorizontalRule" then
+        return "\\hrule\n\n"
+    else
+        return ""
+    end
+end
+
+function Writer(doc, opts)
+    local out  = {}
+    local meta = doc.meta
+
+    table.insert(out, "\\documentclass[11pt,a4paper]{article}")
+    table.insert(out, "\\usepackage[margin=1in]{geometry}")
+    table.insert(out, "\\usepackage[T1]{fontenc}")
+    table.insert(out, "\\usepackage{lmodern}")
+    table.insert(out, "\\usepackage{hyperref}")
+    table.insert(out, "\\usepackage{booktabs}")
+    table.insert(out, "\\usepackage{microtype}")
+
+    local title = meta.title  and pandoc.utils.stringify(meta.title)  or ""
+    local author= meta.author and pandoc.utils.stringify(meta.author) or ""
+
+    if title  ~= "" then table.insert(out, "\\title{"  .. escape(title)  .. "}") end
+    if author ~= "" then table.insert(out, "\\author{" .. escape(author) .. "}") end
+    table.insert(out, "\\date{\\today}")
+
+    table.insert(out, "\\begin{document}")
+    if title ~= "" then table.insert(out, "\\maketitle") end
+
+    for _, block in ipairs(doc.blocks) do
+        table.insert(out, write_block(block))
+    end
+
+    table.insert(out, "\\end{document}")
+    return table.concat(out, "\n")
+end

--- a/docstream/templates/resume.lua
+++ b/docstream/templates/resume.lua
@@ -1,207 +1,101 @@
--- Resume Template for Professional CVs
--- Modern resume template suitable for job applications
+-- Pandoc Lua custom writer: resume / CV template
+-- article class, compact margins, no section numbers
 
-local template = {
-    name = "Resume Template",
-    description = "Professional resume template for job applications",
-    version = "1.0.0",
-    author = "DocStream Team",
-    dependencies = {"geometry", "hyperref", "xcolor", "fontawesome5", "titlesec"}
-}
-
-function template.render(document)
-    local latex = {}
-    
-    -- Document class and packages
-    table.insert(latex, "\\documentclass[11pt,a4paper,sans]{moderncv}")
-    
-    -- ModernCV theme and color
-    table.insert(latex, "\\moderncvstyle{classic}")
-    table.insert(latex, "\\moderncvcolor{blue}")
-    
-    -- Page geometry
-    table.insert(latex, "\\usepackage[scale=0.75]{geometry}")
-    
-    -- Font packages
-    table.insert(latex, "\\usepackage[utf8]{inputenc}")
-    table.insert(latex, "\\usepackage[T1]{fontenc}")
-    
-    -- Hyperlinks
-    table.insert(latex, "\\usepackage{hyperref}")
-    table.insert(latex, "\\hypersetup{colorlinks=true,urlcolor=blue}")
-    
-    -- Additional packages
-    table.insert(latex, "\\usepackage{xcolor}")
-    table.insert(latex, "\\usepackage{titlesec}")
-    
-    -- Custom commands
-    table.insert(latex, "\\name{" .. (document.metadata.first_name or "") .. "}{" .. (document.metadata.last_name or "") .. "}")
-    
-    if document.metadata.address then
-        table.insert(latex, "\\address{" .. escape_latex(document.metadata.address) .. "}")
-    end
-    
-    if document.metadata.phone then
-        table.insert(latex, "\\phone{" .. escape_latex(document.metadata.phone) .. "}")
-    end
-    
-    if document.metadata.email then
-        table.insert(latex, "\\email{" .. escape_latex(document.metadata.email) .. "}")
-    end
-    
-    if document.metadata.website then
-        table.insert(latex, "\\homepage{" .. escape_latex(document.metadata.website) .. "}")
-    end
-    
-    if document.metadata.linkedin then
-        table.insert(latex, "\\social[linkedin]{" .. escape_latex(document.metadata.linkedin) .. "}")
-    end
-    
-    if document.metadata.github then
-        table.insert(latex, "\\social[github]{" .. escape_latex(document.metadata.github) .. "}")
-    end
-    
-    table.insert(latex, "\\begin{document}")
-    table.insert(latex, "\\makecvtitle")
-    
-    -- Main content
-    for _, section in ipairs(document.sections) do
-        table.insert(latex, render_section(section))
-    end
-    
-    table.insert(latex, "\\end{document}")
-    
-    return table.concat(latex, "\n")
-end
-
-function template.render_section(section)
-    local content = {}
-    
-    -- Section heading
-    local section_title = escape_latex(section.title)
-    table.insert(content, "\\section{" .. section_title .. "}")
-    
-    -- Section content
-    for _, block in ipairs(section.blocks) do
-        table.insert(content, render_block(block))
-    end
-    
-    return table.concat(content, "\n")
-end
-
-function template.render_block(block)
-    if block.type == "text" then
-        return escape_latex(block.content) .. "\n\n"
-    elseif block.type == "experience" then
-        return render_experience(block)
-    elseif block.type == "education" then
-        return render_education(block)
-    elseif block.type == "skills" then
-        return render_skills(block)
-    elseif block.type == "list" then
-        return render_list(block)
-    elseif block.type == "heading" then
-        return "\\textbf{" .. escape_latex(block.content) .. "}\n\n"
-    else
-        return escape_latex(block.content) .. "\n\n"
-    end
-end
-
-function template.render_experience(block)
-    local content = {}
-    
-    -- Company and position
-    local company = block.company or ""
-    local position = block.position or ""
-    local location = block.location or ""
-    local start_date = block.start_date or ""
-    local end_date = block.end_date or ""
-    
-    table.insert(content, "\\cventry{" .. escape_latex(start_date .. " -- " .. end_date) .. "}{" .. escape_latex(position) .. "}{" .. escape_latex(company) .. "}{" .. escape_latex(location) .. "}{}{}")
-    
-    -- Description/achievements
-    if block.description then
-        table.insert(content, escape_latex(block.description))
-    end
-    
-    -- Bullet points for achievements
-    if block.achievements and #block.achievements > 0 then
-        for _, achievement in ipairs(block.achievements) do
-            table.insert(content, "\\item " .. escape_latex(achievement))
-        end
-    end
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_education(block)
-    local content = {}
-    
-    local institution = block.institution or ""
-    local degree = block.degree or ""
-    local location = block.location or ""
-    local start_date = block.start_date or ""
-    local end_date = block.end_date or ""
-    local gpa = block.gpa or ""
-    
-    table.insert(content, "\\cventry{" .. escape_latex(start_date .. " -- " .. end_date) .. "}{" .. escape_latex(degree) .. "}{" .. escape_latex(institution) .. "}{" .. escape_latex(location) .. "}{" .. escape_latex(gpa) .. "}{}")
-    
-    if block.details then
-        table.insert(content, escape_latex(block.details))
-    end
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_skills(block)
-    local content = {}
-    
-    if block.skill_categories then
-        for category, skills in pairs(block.skill_categories) do
-            table.insert(content, "\\textbf{" .. escape_latex(category) .. "}: " .. escape_latex(table.concat(skills, ", ")) .. "\\\\")
-        end
-    elseif block.skills then
-        table.insert(content, escape_latex(table.concat(block.skills, ", ")))
-    end
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.render_list(block)
-    local content = {}
-    
-    table.insert(content, "\\begin{itemize}")
-    
-    for _, item in ipairs(block.items or {}) do
-        table.insert(content, "\\item " .. escape_latex(item))
-    end
-    
-    table.insert(content, "\\end{itemize}")
-    
-    return table.concat(content, "\n") .. "\n\n"
-end
-
-function template.escape_latex(text)
+local function escape(text)
     if not text then return "" end
-    
-    local latex_special_chars = {
-        ["&"] = "\\&",
-        ["%"] = "\\%",
-        ["$"] = "\\$",
-        ["#"] = "\\#",
-        ["_"] = "\\_",
-        ["{"] = "\\{",
-        ["}"] = "\\}",
-        ["~"] = "\\textasciitilde{}",
-        ["^"] = "\\^{}",
-        ["\\"] = "\\textbackslash{}",
-    }
-    
-    for char, escaped in pairs(latex_special_chars) do
-        text = string.gsub(text, char, escaped)
-    end
-    
+    text = text:gsub("\\", "\\textbackslash{}")
+    text = text:gsub("%%", "\\%%")
+    text = text:gsub("%$", "\\$")
+    text = text:gsub("&",  "\\&")
+    text = text:gsub("#",  "\\#")
+    text = text:gsub("_",  "\\_")
+    text = text:gsub("{",  "\\{")
+    text = text:gsub("}",  "\\}")
+    text = text:gsub("~",  "\\textasciitilde{}")
+    text = text:gsub("%^", "\\^{}")
     return text
 end
 
-return template
+local function write_inlines(inlines)
+    local parts = {}
+    for _, il in ipairs(inlines) do
+        if     il.t == "Str"       then table.insert(parts, escape(il.c))
+        elseif il.t == "Space"     then table.insert(parts, " ")
+        elseif il.t == "SoftBreak" then table.insert(parts, " ")
+        elseif il.t == "LineBreak" then table.insert(parts, "\\\\\n")
+        elseif il.t == "Strong"    then table.insert(parts, "\\textbf{" .. write_inlines(il.c) .. "}")
+        elseif il.t == "Emph"      then table.insert(parts, "\\emph{"   .. write_inlines(il.c) .. "}")
+        elseif il.t == "Code"      then table.insert(parts, "\\texttt{" .. escape(il.c[2])    .. "}")
+        elseif type(il.c) == "string" then table.insert(parts, escape(il.c))
+        end
+    end
+    return table.concat(parts)
+end
+
+local function write_block(block)
+    if block.t == "Header" then
+        local lvl  = block.c[1]
+        local text = write_inlines(block.c[3])
+        -- No section numbers for resume
+        if     lvl == 1 then return "\\section*{"    .. text .. "}\n\\hrule\\vspace{2pt}\n"
+        elseif lvl == 2 then return "\\subsection*{" .. text .. "}\n"
+        else                  return "\\subsubsection*{" .. text .. "}\n"
+        end
+    elseif block.t == "Para" then
+        return write_inlines(block.c) .. "\n\n"
+    elseif block.t == "Plain" then
+        return write_inlines(block.c) .. "\n"
+    elseif block.t == "BlockQuote" then
+        local inner = {}
+        for _, b in ipairs(block.c) do table.insert(inner, write_block(b)) end
+        return table.concat(inner)
+    elseif block.t == "CodeBlock" then
+        return "\\begin{verbatim}\n" .. block.c[2] .. "\n\\end{verbatim}\n\n"
+    elseif block.t == "BulletList" then
+        local items = {"\\begin{itemize}\\setlength{\\itemsep}{0pt}"}
+        for _, item in ipairs(block.c) do
+            local blocks = {}
+            for _, b in ipairs(item) do table.insert(blocks, write_block(b)) end
+            table.insert(items, "\\item " .. table.concat(blocks))
+        end
+        table.insert(items, "\\end{itemize}\n")
+        return table.concat(items, "\n")
+    elseif block.t == "HorizontalRule" then
+        return "\\hrule\n\n"
+    else
+        return ""
+    end
+end
+
+function Writer(doc, opts)
+    local out  = {}
+    local meta = doc.meta
+
+    table.insert(out, "\\documentclass[10pt,a4paper]{article}")
+    table.insert(out, "\\usepackage[top=0.6in,bottom=0.6in,left=0.75in,right=0.75in]{geometry}")
+    table.insert(out, "\\usepackage[T1]{fontenc}")
+    table.insert(out, "\\usepackage{lmodern}")
+    table.insert(out, "\\usepackage{enumitem}")
+    table.insert(out, "\\usepackage{hyperref}")
+    table.insert(out, "\\usepackage{microtype}")
+    table.insert(out, "\\setlength{\\parindent}{0pt}")
+    table.insert(out, "\\pagestyle{empty}")
+
+    local title  = meta.title  and pandoc.utils.stringify(meta.title)  or ""
+    local author = meta.author and pandoc.utils.stringify(meta.author) or ""
+
+    table.insert(out, "\\begin{document}")
+
+    if author ~= "" then
+        table.insert(out, "{\\Large\\bfseries " .. escape(author) .. "}\\\\[4pt]")
+    elseif title ~= "" then
+        table.insert(out, "{\\Large\\bfseries " .. escape(title)  .. "}\\\\[4pt]")
+    end
+
+    for _, block in ipairs(doc.blocks) do
+        table.insert(out, write_block(block))
+    end
+
+    table.insert(out, "\\end{document}")
+    return table.concat(out, "\n")
+end

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,174 +1,323 @@
 """
-Tests for the Renderer module.
+Tests for Phase-3 DocumentRenderer.
 
-This module contains unit tests for template-based output generation.
-File system and subprocess calls are mocked where appropriate.
+All subprocess calls (pandoc, xelatex) are mocked so tests run
+without a real TeX installation and finish in milliseconds.
 """
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from docstream.core.renderer import LuaRenderer, Renderer, TemplateInfo, TemplateType
+from docstream.core.renderer import DocumentRenderer
 from docstream.exceptions import RenderingError
+from docstream.models.document import DocumentAST, DocumentMetadata, Section
+
+# ---------------------------------------------------------------------------
+# Shared fixtures & helpers
+# ---------------------------------------------------------------------------
+
+FAKE_TEX = "\\documentclass{article}\\begin{document}Hello world\\end{document}"
 
 
-class TestLuaRenderer:
-    """Unit tests for LuaRenderer."""
-
-    def test_list_templates_returns_list(self, tmp_path):
-        """LuaRenderer.list_templates should return a list."""
-        renderer = LuaRenderer(template_dir=str(tmp_path))
-        assert isinstance(renderer._template_cache, dict)
-
-    def test_get_template_path_raises_for_unknown(self, tmp_path):
-        """LuaRenderer should raise RenderingError for unknown template names."""
-        renderer = LuaRenderer(template_dir=str(tmp_path))
-        with pytest.raises(RenderingError):
-            renderer._get_template_path("nonexistent_template")
-
-    def test_get_template_path_accepts_full_path(self, tmp_path):
-        """LuaRenderer should accept a full path to a template file."""
-        template_file = tmp_path / "custom.lua"
-        template_file.write_text("-- empty template")
-        renderer = LuaRenderer(template_dir=str(tmp_path))
-        path = renderer._get_template_path(str(template_file))
-        assert path == str(template_file)
-
-    def test_escape_latex_ampersand(self):
-        """_escape_latex should escape & as \\&."""
-        renderer = LuaRenderer()
-        result = renderer._escape_latex("a & b")
-        assert r"\&" in result
-
-    def test_escape_latex_percent(self):
-        """_escape_latex should escape % as \\%."""
-        renderer = LuaRenderer()
-        result = renderer._escape_latex("50% done")
-        assert r"\%" in result
-
-    def test_escape_latex_dollar(self):
-        """_escape_latex should escape $ as \\$."""
-        renderer = LuaRenderer()
-        result = renderer._escape_latex("$100")
-        assert r"\$" in result
-
-    def test_escape_latex_empty_string(self):
-        """_escape_latex should handle empty strings gracefully."""
-        renderer = LuaRenderer()
-        assert renderer._escape_latex("") == ""
-
-    def test_template_cache_populated_after_load(self, tmp_path):
-        """Template cache should contain template after first load."""
-        template_file = tmp_path / "test.lua"
-        template_file.write_text("-- simple template")
-        renderer = LuaRenderer(template_dir=str(tmp_path))
-        renderer._load_template(str(template_file))
-        assert str(template_file) in renderer._template_cache
-
-    def test_join_blocks_returns_string(self, sample_document_ast):
-        """_join_blocks should concatenate block contents."""
-        renderer = LuaRenderer()
-        blocks = sample_document_ast.sections[0].blocks
-        result = renderer._join_blocks(blocks)
-        assert isinstance(result, str)
-
-    def test_render_raises_for_missing_template(self, sample_document_ast):
-        """render() should raise RenderingError when template is not found."""
-        renderer = LuaRenderer(template_dir="/nonexistent/dir")
-        with pytest.raises(RenderingError):
-            renderer.render(sample_document_ast, "missing_template")
+@pytest.fixture
+def simple_ast():
+    """Minimal DocumentAST with one section — used by all renderer tests."""
+    meta = DocumentMetadata(title="Test Document", author="Test Author")
+    section = Section(
+        heading="Introduction",
+        level=1,
+        content=["This is a test paragraph.", "Second paragraph of the introduction."],
+    )
+    return DocumentAST(
+        title="Test Document",
+        authors=["Test Author"],
+        metadata=meta,
+        sections=[section],
+    )
 
 
-class TestRenderer:
-    """Unit tests for the main Renderer class."""
+def _make_subprocess_mock(
+    xelatex_fail: bool = False,
+    xelatex_log_content: str | None = None,
+    pandoc_fail: bool = False,
+):
+    """Return a callable suitable for use as subprocess.run side_effect."""
 
-    def test_list_templates_includes_builtins(self, tmp_path):
-        """list_templates should include built-in template names."""
-        renderer = Renderer(template_dir=str(tmp_path))
-        templates = renderer.list_templates()
-        for t in TemplateType:
-            assert t.value in templates
+    def _run(cmd, **kwargs):  # noqa: ANN001
+        if not cmd:
+            return MagicMock(returncode=0)
+        prog = cmd[0]
 
-    def test_get_template_info_ieee(self):
-        """get_template_info should return TemplateInfo for ieee."""
-        renderer = Renderer()
-        info = renderer.get_template_info(TemplateType.IEEE)
-        assert isinstance(info, TemplateInfo)
-        assert info.name == "IEEE"
+        # ---- pandoc --version (init check) --------------------------------
+        if prog == "pandoc" and len(cmd) > 1 and cmd[1] == "--version":
+            return MagicMock(returncode=0, stdout="pandoc 3.1.3", stderr="")
 
-    def test_get_template_info_report(self):
-        """get_template_info should return TemplateInfo for report."""
-        renderer = Renderer()
-        info = renderer.get_template_info(TemplateType.REPORT)
-        assert isinstance(info, TemplateInfo)
+        # ---- pandoc JSON → LaTeX conversion --------------------------------
+        if prog == "pandoc":
+            if pandoc_fail:
+                return MagicMock(returncode=1, stdout="", stderr="pandoc: fatal error")
+            return MagicMock(returncode=0, stdout=FAKE_TEX, stderr="")
 
-    def test_get_template_info_resume(self):
-        """get_template_info should return TemplateInfo for resume."""
-        renderer = Renderer()
-        info = renderer.get_template_info(TemplateType.RESUME)
-        assert isinstance(info, TemplateInfo)
+        # ---- xelatex -------------------------------------------------------
+        if prog == "xelatex":
+            cwd = kwargs.get("cwd", ".")
+            if xelatex_log_content:
+                Path(cwd, "document.log").write_text(xelatex_log_content, encoding="utf-8")
+            if xelatex_fail:
+                return MagicMock(returncode=1, stdout="", stderr="xelatex: compilation failed")
+            # Success: create a fake PDF so _compile_latex finds the file
+            Path(cwd, "document.pdf").write_bytes(b"%PDF-1.4 fake-pdf-content")
+            return MagicMock(returncode=0, stdout="", stderr="")
 
-    def test_get_template_info_custom_string(self):
-        """get_template_info with a custom string should return TemplateInfo."""
-        renderer = Renderer()
-        info = renderer.get_template_info("my_custom_template")
-        assert isinstance(info, TemplateInfo)
-        assert info.name == "my_custom_template"
+        return MagicMock(returncode=0)
 
-    def test_validate_template_returns_false_for_missing(self, tmp_path):
-        """validate_template should return False when file is missing."""
-        renderer = Renderer(template_dir=str(tmp_path))
-        result = renderer.validate_template("/nonexistent/template.lua")
-        assert result is False
-
-    def test_validate_template_returns_true_for_valid_file(self, tmp_path):
-        """validate_template should return True for an existing file."""
-        template_file = tmp_path / "valid.lua"
-        template_file.write_text("-- valid lua template")
-        renderer = Renderer(template_dir=str(tmp_path))
-        result = renderer.validate_template(str(template_file))
-        assert result is True
-
-    def test_render_to_latex_returns_string(self, sample_document_ast, tmp_path):
-        """render_to_latex should return a non-empty string."""
-        template_file = tmp_path / "report.lua"
-        template_file.write_text("-- stub report template")
-        renderer = Renderer(template_dir=str(tmp_path))
-        result = renderer.render_to_latex(sample_document_ast, "report")
-        assert isinstance(result, str)
+    return _run
 
 
-class TestTemplateType:
-    """Tests for the TemplateType enum."""
-
-    def test_enum_values(self):
-        """TemplateType values should match expected strings."""
-        assert TemplateType.IEEE.value == "ieee"
-        assert TemplateType.REPORT.value == "report"
-        assert TemplateType.RESUME.value == "resume"
-
-    def test_enum_from_string(self):
-        """TemplateType should be constructable from string value."""
-        assert TemplateType("ieee") == TemplateType.IEEE
-        assert TemplateType("report") == TemplateType.REPORT
+# ---------------------------------------------------------------------------
+# test_render_report_template
+# ---------------------------------------------------------------------------
 
 
-class TestTemplateInfo:
-    """Tests for the TemplateInfo dataclass."""
+class TestRenderReportTemplate:
+    """DocumentRenderer with 'report' template — success path."""
 
-    def test_defaults(self):
-        """TemplateInfo should have sensible defaults."""
-        info = TemplateInfo(name="test", description="A test template")
-        assert info.version == "1.0.0"
-        assert info.dependencies == []
+    def test_success_is_true(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.success is True
 
-    def test_custom_values(self):
-        """TemplateInfo should store custom values."""
-        info = TemplateInfo(
-            name="custom",
-            description="Custom template",
-            version="2.0.0",
-            author="Me",
-            dependencies=["geometry", "fancyhdr"],
-        )
-        assert info.author == "Me"
-        assert "geometry" in info.dependencies
+    def test_template_used_is_report(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.template_used == "report"
+
+    def test_tex_path_is_set_and_has_correct_suffix(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.tex_path is not None
+        assert Path(result.tex_path).suffix == ".tex"
+
+    def test_pdf_path_is_set_and_has_correct_suffix(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.pdf_path is not None
+        assert Path(result.pdf_path).suffix == ".pdf"
+
+    def test_processing_time_is_non_negative(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.processing_time_seconds >= 0.0
+
+    def test_error_field_is_none_on_success(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# test_render_ieee_template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderIeeeTemplate:
+    """DocumentRenderer with 'ieee' template — success path."""
+
+    def test_success_is_true(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("ieee")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.success is True
+
+    def test_template_used_is_ieee(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("ieee")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.template_used == "ieee"
+
+    def test_unknown_template_raises_value_error(self):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            with pytest.raises(ValueError, match="Unknown template"):
+                DocumentRenderer("nonexistent_template")
+
+    def test_all_three_valid_templates_accepted(self):
+        for tpl in ("report", "ieee", "resume"):
+            with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+                renderer = DocumentRenderer(tpl)
+                assert renderer.template == tpl
+
+
+# ---------------------------------------------------------------------------
+# test_render_resume_template
+# ---------------------------------------------------------------------------
+
+
+class TestRenderResumeTemplate:
+    """DocumentRenderer with 'resume' template — success path."""
+
+    def test_success_is_true(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("resume")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.success is True
+
+    def test_template_used_is_resume(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("resume")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.template_used == "resume"
+
+    def test_output_dir_is_created(self, simple_ast, tmp_path):
+        out_dir = tmp_path / "output" / "nested"
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("resume")
+            result = renderer.render(simple_ast, out_dir)
+        assert result.success is True
+        assert out_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# test_latex_error_parsed_correctly
+# ---------------------------------------------------------------------------
+
+
+class TestLatexErrorParsedCorrectly:
+    """xelatex failure → error is parsed from .log and surfaced."""
+
+    def test_success_is_false_on_xelatex_failure(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock(xelatex_fail=True)):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.success is False
+
+    def test_error_field_is_populated(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock(xelatex_fail=True)):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.error is not None
+        assert len(result.error) > 0
+
+    def test_log_bang_lines_appear_in_error(self, simple_ast, tmp_path):
+        log = "! Undefined control sequence.\n! Emergency stop.\n"
+        with patch(
+            "subprocess.run",
+            side_effect=_make_subprocess_mock(xelatex_fail=True, xelatex_log_content=log),
+        ):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert "Undefined control sequence" in result.error
+
+    def test_template_used_still_recorded_on_failure(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock(xelatex_fail=True)):
+            renderer = DocumentRenderer("report")
+            result = renderer.render(simple_ast, tmp_path)
+        assert result.template_used == "report"
+
+
+# ---------------------------------------------------------------------------
+# test_cleanup_on_failure
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupOnFailure:
+    """_cleanup is always called in finally — even when rendering fails."""
+
+    def test_cleanup_called_on_xelatex_failure(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock(xelatex_fail=True)):
+            renderer = DocumentRenderer("report")
+            with patch.object(renderer, "_cleanup") as mock_cleanup:
+                result = renderer.render(simple_ast, tmp_path)
+        assert result.success is False
+        assert mock_cleanup.call_count >= 1
+
+    def test_cleanup_called_on_pandoc_failure(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock(pandoc_fail=True)):
+            renderer = DocumentRenderer("report")
+            with patch.object(renderer, "_cleanup") as mock_cleanup:
+                result = renderer.render(simple_ast, tmp_path)
+        assert result.success is False
+        assert mock_cleanup.call_count >= 1
+
+    def test_cleanup_called_on_success_too(self, simple_ast, tmp_path):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+            with patch.object(renderer, "_cleanup") as mock_cleanup:
+                result = renderer.render(simple_ast, tmp_path)
+        assert result.success is True
+        assert mock_cleanup.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# test_pandoc_not_found_error
+# ---------------------------------------------------------------------------
+
+
+class TestPandocNotFoundError:
+    """Missing pandoc binary raises RenderingError at __init__ time."""
+
+    def test_raises_rendering_error(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError("pandoc: not found")):
+            with pytest.raises(RenderingError):
+                DocumentRenderer("report")
+
+    def test_error_message_mentions_pandoc_org(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            try:
+                DocumentRenderer("report")
+                pytest.fail("Expected RenderingError was not raised")
+            except RenderingError as exc:
+                assert "pandoc.org" in str(exc)
+
+    def test_rendering_error_not_file_not_found_error(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            exc_caught = None
+            try:
+                DocumentRenderer("report")
+            except RenderingError as exc:
+                exc_caught = exc
+        assert exc_caught is not None
+        assert isinstance(exc_caught, RenderingError)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _ast_to_pandoc_json
+# ---------------------------------------------------------------------------
+
+
+class TestAstToPandocJson:
+    """Direct unit tests for the Pandoc JSON conversion helper."""
+
+    def test_output_has_required_top_level_keys(self, simple_ast):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+        pj = renderer._ast_to_pandoc_json(simple_ast)
+        assert "pandoc-api-version" in pj
+        assert "meta" in pj
+        assert "blocks" in pj
+
+    def test_blocks_are_non_empty_for_non_trivial_ast(self, simple_ast):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+        pj = renderer._ast_to_pandoc_json(simple_ast)
+        assert len(pj["blocks"]) > 0
+
+    def test_header_block_present_for_section(self, simple_ast):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+        pj = renderer._ast_to_pandoc_json(simple_ast)
+        types = [b["t"] for b in pj["blocks"]]
+        assert "Header" in types
+
+    def test_title_in_meta(self, simple_ast):
+        with patch("subprocess.run", side_effect=_make_subprocess_mock()):
+            renderer = DocumentRenderer("report")
+        pj = renderer._ast_to_pandoc_json(simple_ast)
+        assert "title" in pj["meta"]


### PR DESCRIPTION
- implement DocumentRenderer class (render, _ast_to_pandoc_json, _run_pandoc, _compile_latex, _cleanup)
- add ConversionResult Phase-3 fields: tex_path, pdf_path, error, processing_time_seconds, template_used
- rewrite Lua templates as proper Pandoc 3.x custom writers (report, ieee, resume)
- run xelatex twice for cross-reference support, parse .log for ! errors
- pandoc availability check on __init__, RenderingError on missing binary
- temp dir management with mkdtemp + finally cleanup
- 27 tests in test_renderer.py — all passing (64/64 total)

## Description
Brief description of the changes made in this pull request.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the existing test suite and it passes
- [ ] I have checked that my code follows the project's style guidelines

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context
Any additional context, screenshots, or information about the pull request.
